### PR TITLE
Parse Twilio Response for non-successes

### DIFF
--- a/steps/twilio-step-send-sms/pkg/twilio/sender.go
+++ b/steps/twilio-step-send-sms/pkg/twilio/sender.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/relay-integrations/relay-twilio/actions/steps/send-sms/pkg/logs"
 )
@@ -21,6 +22,10 @@ type twilioResponse struct {
 	SID string `json:"sid"`
 }
 
+type twilioErrorResponse struct {
+	Message string `json:"message"`
+}
+
 func (s Sender) Send(to, body string) error {
 	urlStr := "https://api.twilio.com/2010-04-01/Accounts/" + s.accountSID + "/Messages.json"
 
@@ -30,7 +35,11 @@ func (s Sender) Send(to, body string) error {
 	msgData.Set("Body", body)
 
 	client := &http.Client{}
-	req, _ := http.NewRequest("POST", urlStr, strings.NewReader(msgData.Encode()))
+	// Timeout in the HTTP Client includes the entire request liftime, including connection + response body read.
+	// If somehow Twilio starts behaving maliciously and returning a slow request, this will handle that case
+	// The time is extremely long, but it really just shouldn't be infinite
+	client.Timeout = 15 * time.Minute
+	req, _ := http.NewRequest(http.MethodPost, urlStr, strings.NewReader(msgData.Encode()))
 	req.SetBasicAuth(s.accountSID, s.authToken)
 
 	req.Header.Add("Accept", "application/json")
@@ -47,16 +56,19 @@ func (s Sender) Send(to, body string) error {
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		var data twilioResponse
-
 		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 			logger.WithError(err).Error("failed to parse Twilio response")
 		} else {
 			logger.Debugf("message `%s` delivered", data.SID)
 		}
-
-		// TODO: We should actually return an error here...
 	} else {
-		logger.Errorf("invalid twilio response code: %s", resp.Status)
+		var errResp twilioErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			logger.WithError(err).Error("failed to parse Twilio error response")
+			return err
+		}
+		logger.Errorf("invalid twilio response code: %s - %s", resp.Status, errResp.Message)
+		// TODO: We should actually return an error here...
 	}
 
 	return nil


### PR DESCRIPTION
When Twilio returns a non-200 code, log the reason that twilio gives. This is an extra network read, but we are already reading the much larger response in the success path, so the cost here is small.